### PR TITLE
Only unlink existing files

### DIFF
--- a/src/Filesystem.php
+++ b/src/Filesystem.php
@@ -66,6 +66,10 @@ class Filesystem
      */
     public static function delete($path)
     {
+        if (!file_exists($path)) {
+            return true;
+        }
+
         return unlink($path);
     }
 


### PR DESCRIPTION
If for any reason the index file does not exist the delete action should be considered successful.

Whithout this check the deletion of non-existent DB entries fails with an ErrorException.