### PR TITLE
#42 Sort by update or create time

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -434,6 +434,16 @@ class Document
             return $context;
         }
 
+        if ($field == '__created_at')
+        {
+            return $this->__created_at;
+        }
+
+        if ($field == '__updated_at')
+        {
+            return $this->__updated_at;
+        }
+
         foreach($parts as $part)
         {
             if (trim($part) == '')

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -518,6 +518,26 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $db->flush(true);
     }
 
+    public function testFieldTimestamps()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases'
+        ]);
+
+        $db->flush(true);
+
+        $db->get('vegetables')->set(['broccoli'=>'27'])->save();
+
+        $expected = time();
+        $actual = $db->get('vegetables')->field('__created_at');
+        $this->assertEquals($expected, $actual);
+
+        $actual = $db->get('vegetables')->field('__updated_at');
+        $this->assertEquals($expected, $actual);
+
+        $db->flush(true);
+    }
+
 
     public function testNestedFieldMethod()
     {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1045,4 +1045,54 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $db->flush(true);
     }
 
+    public function testSortByTimes()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/_testsort'
+        ]);
+
+        $db->flush(true);
+
+        // Create some docs with time in between to get different timestamps
+        $doc = $db->get('record1')->set(['name'=>'a'])->save();
+        sleep(1);
+        $doc = $db->get('record2')->set(['name'=>'b'])->save();
+        sleep(1);
+        $doc = $db->get('record3')->set(['name'=>'c'])->save();
+
+        $documents = $db->query()->orderBy('__created_at', 'DESC')->results();
+        $expected = [
+            ['name' => 'c'],
+            ['name' => 'b'],
+            ['name' => 'a'],
+        ];
+        $this->assertEquals($expected, $documents);
+
+        $documents = $db->query()->orderBy('__created_at', 'ASC')->results();
+        $expected = [
+            ['name' => 'a'],
+            ['name' => 'b'],
+            ['name' => 'c'],
+        ];
+        $this->assertEquals($expected, $documents);
+
+        $documents = $db->query()->orderBy('__updated_at', 'DESC')->results();
+        $expected = [
+            ['name' => 'c'],
+            ['name' => 'b'],
+            ['name' => 'a'],
+        ];
+        $this->assertEquals($expected, $documents);
+
+        $documents = $db->query()->orderBy('__updated_at', 'ASC')->results();
+        $expected = [
+            ['name' => 'a'],
+            ['name' => 'b'],
+            ['name' => 'c'],
+        ];
+        $this->assertEquals($expected, $documents);
+
+        $db->flush(true);
+    }
+
 }


### PR DESCRIPTION
I created this small enhancement to allow users to sort documents by created_at and updated_at. It works by doing the following in a query:

```
$documents = $db->query()->orderBy('__created_at', 'DESC')->results();
// or
$documents = $db->query()->orderBy('__updated_at', 'DESC')->results();
```

It works is because I added the ability to fetch those fields from `Document::field()` method.