### PR TITLE
#40 Add ability to query on document ids

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -434,6 +434,10 @@ class Document
             return $context;
         }
 
+        if ($field == '__id') {
+            return $this->__id;
+        }
+
         foreach($parts as $part)
         {
             if (trim($part) == '')

--- a/tests/DocumentTest.php
+++ b/tests/DocumentTest.php
@@ -518,6 +518,22 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $db->flush(true);
     }
 
+    public function testFieldId()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases'
+        ]);
+
+        $db->flush(true);
+
+        $db->get('weather')->set(['cityname'=>'condition1'])->save();
+
+        $actual = $db->get('weather')->field('__id');
+        $this->assertEquals('weather', $actual);
+
+        $db->flush(true);
+    }
+
 
     public function testNestedFieldMethod()
     {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1045,4 +1045,35 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $db->flush(true);
     }
 
+    /**
+     * testWhereInUsingDocId
+     *
+     * TEST CASE:
+     * - Testing the where "IN" operator when applied to the document ids to fetch
+     */
+    public function testWhereInUsingDocId()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/users_1',
+            'cache' => false
+        ]);
+
+        $db->flush(true);
+
+        $user1 = $db->get('obj1')->save(['name' => 'Bob']);
+        $user2 = $db->get('obj2')->save(['name' => 'Jenny']);
+        $user3 = $db->get('obj3')->save(['name' => 'Cyrus']);
+
+        // Make sure it works with just one
+        $test1 = $db->query()->where('__id', '=', 'obj1')->first();
+        $expected = ['name' => 'Bob'];
+        $this->assertEquals($expected, $test1);
+
+        // Make sure it works with a list
+        $test2 = $db->query()->where('__id', 'IN', ['obj2', 'obj3'])->results();
+        $expected = [['name' => 'Jenny'], ['name' => 'Cyrus']];
+        $this->assertEquals($expected, $test2);
+
+        $db->flush(true);
+    }
 }


### PR DESCRIPTION
This pull request updates the logic to support using where clause to find documents by id.

The way to do it is to use the special name `__id`.

```
// Given objects in database having ids like "obj2" and "obj3", can fetch them using this:
$results = $db->query()->where('__id', 'IN', ['obj2', 'obj3'])->results();
```

This update was accomplished by updating `Document::field()` to accept an argument value of "__id" which will return the objects (internal) id.