### PR TITLE
*new_feature: delete items with custom filter 

### DIFF
--- a/src/Query.php
+++ b/src/Query.php
@@ -269,5 +269,21 @@ class Query extends QueryLogic
 
 
     //--------------------------------------------------------------------
-
+    
+    public function delete($input)
+    {
+        $items=$this->resultDocuments();
+        $condition=$input;
+        foreach($items as $item)
+        {
+            if(is_object($input))
+            {
+                $condition=$input($item);
+            }
+            if($condition)
+            {
+                $item->delete();
+            }
+        }
+    }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1044,5 +1044,39 @@ class QueryTest extends \PHPUnit\Framework\TestCase
 
         $db->flush(true);
     }
+    public function testDeleteWhereMatchItemsWithCustomFilter()
+    {   
+        $db = new \Filebase\Database([
+            'dir' => 'path/to/users/users/test',
+        ]);
+        $db->flush(true);
+
+        $a=0;
+        while($a < 15)
+        {
+            $user=$db->get($a."username");
+            $user->name  = $a.'John';
+            $user->email = 'john@example.com';
+            $user->tags  = ['php','developer','html5'];
+
+    		$user->save();
+            $a++;
+        }
+        $actual=$db->query()->results();
+        $this->assertCount(15,$actual);
+        $r=$db->query()->where('name','LIKE','john')->resultDocuments();
+        $this->assertInstanceOf(Document::class, $r[0]);
+
+        $db->query()->where('name','LIKE','john')->delete(function($item){
+
+            return $item->name=='0John';
+
+        });
+        $actual=$db->query()->where('name','LIKE','john')->resultDocuments();
+        $this->assertCount(14,$actual);
+        $db->flush(true);
+
+    }
+
 
 }


### PR DESCRIPTION
This pull request updates the query::class to support delete  query results  using custom filter.

$db->query()->where('name','LIKE','john')->delete(function($item){

            return $item->name=='0John' && $item->email==some@mail.com;

});