### PR TITLE
call to "Query::class" methods directly

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -488,4 +488,17 @@ class Database
         return $this->config;
     }
 
+    public function __call($method,$args)
+    {
+        if(method_exists($this,$method))
+        {
+            return $this->$method(...$args);
+        }
+        if(method_exists(Query::class,$method))
+        {
+            return (new Query($this))->$method(...$args);
+        }
+        throw new \BadMethodCallException("method {$method} not found on 'Database::class' and 'Query::class'");
+    }
+
 }

--- a/src/Database.php
+++ b/src/Database.php
@@ -96,26 +96,25 @@ class Database
         $file_location  = $this->config->dir.'/';
 
         $all_items = Filesystem::getAllFiles($file_location, $file_extension);
-        if ($include_documents==true)
+        if (!$include_documents)
         {
-            $items = [];
+            return $all_items;
+        }
+        $items = [];
 
-            foreach($all_items as $a)
-        	{
-                if ($data_only === true)
-                {
-                    $items[] = $this->get($a)->getData();
-                }
-                else
-                {
-                    $items[] = $this->get($a);
-                }
-        	}
-
-            return $items;
+        foreach($all_items as $a)
+        {
+            if ($data_only === true)
+            {
+                $items[] = $this->get($a)->getData();
+            }
+            else
+            {
+                $items[] = $this->get($a);
+            }
         }
 
-        return $all_items;
+        return $items;
     }
 
 
@@ -283,10 +282,8 @@ class Database
 
             return $document;
         }
-        else
-        {
-            return false;
-        }
+       
+        return false;
     }
 
 
@@ -393,28 +390,24 @@ class Database
             throw new Exception("This database is set to be read-only. No modifications can be made.");
         }
 
-        if ($confirm===true)
-        {
-            $format = $this->config->format;
-            $documents = $this->findAll(false);
-            foreach($documents as $document)
-            {
-                Filesystem::delete($this->config->dir.'/'.$document.'.'.$format::getFileExtension());
-            }
-
-            if ($this->count() === 0)
-            {
-                return true;
-            }
-            else
-            {
-                throw new Exception("Could not delete all database files in ".$this->config->dir);
-            }
-        }
-        else
+        if ($confirm!==true)
         {
             throw new Exception("Database Flush failed. You must send in TRUE to confirm action.");
         }
+
+        $format = $this->config->format;
+        $documents = $this->findAll(false);
+        foreach($documents as $document)
+        {
+            Filesystem::delete($this->config->dir.'/'.$document.'.'.$format::getFileExtension());
+        }
+
+        if ($this->count() === 0)
+        {
+            return true;
+        }
+        
+        throw new Exception("Could not delete all database files in ".$this->config->dir);
     }
 
 

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -258,4 +258,54 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
 
         $doc->save();
     }
+    public function test_Call_Queryclass_methods_on_database_without_query_method()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/saved',
+            'cache' => true
+        ]);
+
+        $db->flush(true);
+
+        for ($x = 1; $x <= 10; $x++)
+    	{
+    		$user = $db->get(uniqid());
+    		$user->name  = 'John';
+            $user->email = 'john@example.com';
+    		$user->save();
+    	}
+
+        $results = $db->where('name','=','John')->andWhere('email','==','john@example.com')->resultDocuments();
+        $result_from_cache = $db->where('name','=','John')->andWhere('email','==','john@example.com')->resultDocuments();
+
+        $this->assertEquals(10, count($results));
+        $this->assertEquals(true, ($result_from_cache[0]->isCache()));
+
+        $id = $result_from_cache[0]->getId();
+        $id2 = $result_from_cache[1]->getId();
+
+        // Change the name
+        $result_from_cache[0]->name = 'Tim';
+        $result_from_cache[0]->save();
+
+        $results = $db
+    	 	->where('name','=','John')
+            ->andWhere('email','==','john@example.com')
+    		->resultDocuments();
+
+        $this->assertEquals($id2, $results[0]->getId());
+        $this->assertEquals('John', $results[0]->name);
+
+        $db->flush(true);
+    }
+    public function test_must_return_exception_on_non_exist_method()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/saved',
+            'cache' => true
+        ]);
+
+        $this->expectException(\BadMethodCallException::class);
+        $results = $db->none('name','=','John')->andWhere('email','==','john@example.com')->resultDocuments();
+    }
 }


### PR DESCRIPTION
new ability added to database for call query methods directly. for this __call added in to "database.php" :
for ex:
$database->query()->where('name','foo')->result();  //working
also 
$database->where('name','foo')->result();  //working

and some other refactors
;)