### PR TITLE
Support sorting by multiple columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,12 @@ $usersWithGmail = $db->query()
                     ->orderBy('email', 'ASC')
                     ->results();
 
+// OrderBy can be applied multiple times to perform a multi-sort
+$usersWithGmail = $db->query()
+                    ->where('email','LIKE','@gmail.com')
+                    ->orderBy('last_name', 'ASC')
+                    ->orderBy('email', 'ASC')
+                    ->results();
 
 // this will return the first user in the list based on ascending order of user name.
 $user = $db->query()->orderBy('name', 'ASC')->first();

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Filebase is simple by design, but has enough features for the more advanced.
 * File locking (on save)
 * Intuitive Method Naming
 
-
 ## Installation
 
 Use [Composer](http://getcomposer.org/) to install package.

--- a/src/Query.php
+++ b/src/Query.php
@@ -7,8 +7,8 @@ class Query extends QueryLogic
     protected $fields  = [];
     protected $limit   = 0;
     protected $offset  = 0;
-    protected $sortBy  = 'ASC';
-    protected $orderBy = '';
+    protected $sortBy  = ['ASC'];
+    protected $orderBy = [''];
 
 
     /**
@@ -116,8 +116,13 @@ class Query extends QueryLogic
     */
     public function orderBy($field, $sort)
     {
-        $this->orderBy = $field;
-        $this->sortBy  = $sort;
+        if (count($this->orderBy) == 1 && $this->orderBy[0] == '') {
+            $this->orderBy[0] = $field;
+            $this->sortBy[0]  = $sort;
+        } else {
+            $this->orderBy[] = $field;
+            $this->sortBy[]  = $sort;
+        }
 
         return $this;
     }

--- a/src/Query.php
+++ b/src/Query.php
@@ -114,14 +114,15 @@ class Query extends QueryLogic
     * ->orderBy()
     *
     */
-    public function orderBy($field, $sort)
+    public function orderBy($field, $sort = 'ASC')
     {
         if (count($this->orderBy) == 1 && $this->orderBy[0] == '') {
+            // Just set the initial index
             $this->orderBy[0] = $field;
-            $this->sortBy[0]  = $sort;
+            $this->sortBy[0]  = strtoupper($sort);
         } else {
             $this->orderBy[] = $field;
-            $this->sortBy[]  = $sort;
+            $this->sortBy[]  = strtoupper($sort);
         }
 
         return $this;

--- a/src/QueryLogic.php
+++ b/src/QueryLogic.php
@@ -1,5 +1,6 @@
 <?php  namespace Filebase;
 
+use Filebase\SortLogic;
 
 class QueryLogic
 {
@@ -190,45 +191,15 @@ class QueryLogic
     * sort
     *
     */
-    protected function sort($orderBy = null, $sortBy = null, $i = 0)
+    protected function sort()
     {
-        $orderBy = ($orderBy == null) ? $this->orderBy[$i] : $orderBy;
-        $sortBy  = ($sortBy == null) ? $this->sortBy[$i] : $sortBy;
-
-        if ($orderBy=='')
+        if ($this->orderBy[0] == '')
         {
             return false;
         }
 
-        $user_sort_function = function($a, $b) use ($orderBy, $sortBy, $i) {
-
-            $propA = $a->field($orderBy);
-            $propB = $b->field($orderBy);
-
-
-            if (strnatcasecmp($propB, $propA) == strnatcasecmp($propA, $propB)) {
-                if (!isset($this->orderBy[$i + 1])) {
-                    return 0;
-                }
-                // If they match and there are multiple orderBys, go deeper (recurse)
-                printf("going deeper %s %s\n", $i, $this->orderBy[$i + 1]);
-                $i = $i + 1;
-                return $user_sort_function($this->orderBy[$i], $this->sortBy[$i]);
-            }
-
-            if ($sortBy == 'DESC')
-            {
-                return (strnatcasecmp($propB, $propA) < strnatcasecmp($propA, $propB)) ? -1 : 1;
-            }
-            else
-            {
-                return (strnatcasecmp($propA, $propB) < strnatcasecmp($propB, $propA)) ? -1 : 1;
-            }
-
-        };
-
-        usort($this->documents, $user_sort_function);
-
+        $sortlogic = new SortLogic($this->orderBy, $this->sortBy, 0);
+        usort($this->documents, [$sortlogic, 'sort']);
     }
 
 

--- a/src/SortLogic.php
+++ b/src/SortLogic.php
@@ -1,0 +1,79 @@
+<?php  namespace Filebase;
+
+/**
+ * Recursive sort logic class
+ *
+ * @package Filebase
+ */
+class SortLogic
+{
+    /**
+     * Field names to sort by
+     *
+     * @var array
+     */
+    public $orderBy = [];
+
+    /**
+     * Sort direction (ASC, DESC)
+     *
+     * @var array
+     */
+    public $sortDirection = [];
+
+    /**
+     * Index of the current sort data
+     *
+     * @var int
+     */
+    public $index = 0;
+
+    /**
+     * Constructor
+     *
+     * @param array $orderBy
+     * @param array $sortDirection
+     * @param int $index
+     * @return void
+     */
+    public function __construct($orderBy, $sortDirection, $index = 0)
+    {
+        $this->orderBy = $orderBy;
+        $this->sortDirection = $sortDirection;
+        $this->index = $index;
+    }
+
+    /**
+     * Sorting callback
+     *
+     * @param Document $docA
+     * @param Document $docB
+     * @return return int (-1, 0, 1)
+     */
+    public function sort($docA, $docB)
+    {
+        $propA = $docA->field($this->orderBy[$this->index]);
+        $propB = $docB->field($this->orderBy[$this->index]);
+
+        if (strnatcasecmp($propA, $propB) == 0)
+        {
+            if (!isset($this->orderBy[$this->index + 1]))
+            {
+                return 0;
+            }
+
+            // If they match and there are multiple orderBys, go deeper (recurse)
+            $sortlogic = new self($this->orderBy, $this->sortDirection, $this->index + 1);
+            return $sortlogic->sort($docA, $docB);
+        }
+
+        if ($this->sortDirection[$this->index] == 'DESC')
+        {
+            return strnatcasecmp($propB, $propA);
+        }
+        else
+        {
+            return strnatcasecmp($propA, $propB);
+        }
+    }
+}

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -498,6 +498,38 @@ class QueryTest extends \PHPUnit\Framework\TestCase
 
     }
 
+    public function testMultiOrderby()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__ . '/databases/users_orderbymult',
+            'cache' => false
+        ]);
+
+        $db->flush(true);
+
+        $companies = ['Google'=>['CA', 150], 'Apple'=>['CA', 180], 'Microsoft'=>['WA', 120], 'Amex'=>['DC', 20], 'Hooli'=>['CA', 50], 'Amazon'=>['PA', 140]];
+
+        foreach ($companies as $company => $data) {
+            $doc = $db->get(uniqid());
+    		$doc->name = $company;
+            $doc->location = $data[0];
+            $doc->rank['reviews'] = $data[1];
+            $doc->status = 'enabled';
+    		$doc->save();
+        }
+
+        $test0 = $db->query()->orderBy('location', 'ASC')->results();
+
+        $test1 = $db->query()->orderBy('location', 'ASC')->orderBy('name', 'ASC')->results();
+        $actual = array_map(function($doc) {
+            return $doc['name'];
+        }, $test1);
+        $expected = ['Apple', 'Google', 'Hooli', 'Amex', 'Amazon', 'Microsoft'];
+        $this->assertEquals($expected, $actual);
+
+        $db->flush(true);
+    }
+
 
     //--------------------------------------------------------------------
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -498,7 +498,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase
 
     }
 
-    public function testMultiOrderby()
+    public function prepareMultiOrderTestData()
     {
         $db = new \Filebase\Database([
             'dir' => __DIR__ . '/databases/users_orderbymult',
@@ -507,7 +507,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase
 
         $db->flush(true);
 
-        $companies = ['Google'=>['CA', 150], 'Apple'=>['CA', 180], 'Microsoft'=>['WA', 120], 'Amex'=>['DC', 20], 'Hooli'=>['CA', 50], 'Amazon'=>['PA', 140]];
+        $companies = ['Google'=>['CA', 150], 'Apple'=>['CA', 180], 'Microsoft'=>['WA', 120], 'Amex'=>['DC', 20], 'Hooli'=>['CA', 150], 'Amazon'=>['PA', 140]];
 
         foreach ($companies as $company => $data) {
             $doc = $db->get(uniqid());
@@ -518,7 +518,26 @@ class QueryTest extends \PHPUnit\Framework\TestCase
     		$doc->save();
         }
 
-        $test0 = $db->query()->orderBy('location', 'ASC')->results();
+        return $db;
+    }
+
+    public function testMultiOrderbyOneOnly()
+    {
+        $db = $this->prepareMultiOrderTestData();
+
+        $test1 = $db->query()->orderBy('location', 'asc')->results();
+        $actual = array_map(function($doc) {
+            return $doc['name'];
+        }, $test1);
+        $expected = ['Google', 'Apple', 'Hooli', 'Amex', 'Amazon', 'Microsoft'];
+        $this->assertEquals($expected, $actual);
+
+        $db->flush(true);
+    }
+
+    public function testMultiOrderbyTwoAscAsc()
+    {
+        $db = $this->prepareMultiOrderTestData();
 
         $test1 = $db->query()->orderBy('location', 'ASC')->orderBy('name', 'ASC')->results();
         $actual = array_map(function($doc) {
@@ -530,6 +549,47 @@ class QueryTest extends \PHPUnit\Framework\TestCase
         $db->flush(true);
     }
 
+    public function testMultiOrderbyTwoDescAsc()
+    {
+        $db = $this->prepareMultiOrderTestData();
+
+        $test2 = $db->query()->orderBy('location', 'desc')->orderBy('name', 'ASC')->results();
+        $actual = array_map(function($doc) {
+            return $doc['name'];
+        }, $test2);
+        $expected = ['Microsoft', 'Amazon', 'Amex', 'Apple', 'Google', 'Hooli'];
+        $this->assertEquals($expected, $actual);
+
+        $db->flush(true);
+    }
+
+    public function testMultiOrderbyTwoAscDesc()
+    {
+        $db = $this->prepareMultiOrderTestData();
+
+        $test3 = $db->query()->orderBy('location', 'ASC')->orderBy('name', 'DESC')->results();
+        $actual = array_map(function($doc) {
+            return $doc['name'];
+        }, $test3);
+        $expected = ['Hooli', 'Google', 'Apple', 'Amex', 'Amazon', 'Microsoft'];
+        $this->assertEquals($expected, $actual);
+
+        $db->flush(true);
+    }
+
+    public function testMultiOrderbyThree()
+    {
+        $db = $this->prepareMultiOrderTestData();
+
+        $test4 = $db->query()->orderBy('location', 'ASC')->orderBy('rank.reviews', 'ASC')->orderBy('name')->results();
+        $actual = array_map(function($doc) {
+            return $doc['name'];
+        }, $test4);
+        $expected = ['Google', 'Hooli', 'Apple', 'Amex', 'Amazon', 'Microsoft'];
+        $this->assertEquals($expected, $actual);
+
+        $db->flush(true);
+    }
 
     //--------------------------------------------------------------------
 

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -525,11 +525,11 @@ class QueryTest extends \PHPUnit\Framework\TestCase
     {
         $db = $this->prepareMultiOrderTestData();
 
-        $test1 = $db->query()->orderBy('location', 'asc')->results();
+        $test1 = $db->query()->orderBy('name', 'asc')->results();
         $actual = array_map(function($doc) {
             return $doc['name'];
         }, $test1);
-        $expected = ['Google', 'Apple', 'Hooli', 'Amex', 'Amazon', 'Microsoft'];
+        $expected = ['Amazon', 'Amex', 'Apple', 'Google', 'Hooli', 'Microsoft'];
         $this->assertEquals($expected, $actual);
 
         $db->flush(true);


### PR DESCRIPTION
This adds the ability to sort by multiple columns.

I ran into a situation where I wanted to sort things by category and then name, but the original orderBy() only allowed sorting by one column. This update allows to call `orderBy()` multiple times and it will sort by the columns in the order that `orderBy` is called.

```
$result = $db->query()
    ->orderBy('category', 'DESC')
    ->orderBy('name', 'ASC');
```

I added tests to fully test this new feature as well.