### PR TITLE
add ability to search with where* like whereName whereCountry ...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Change Log
 ==========
 
+### 02/24/2019 - 1.0.24
+* Merged [Pull Request](https://github.com/filebase/Filebase/pull/50) Fixed [bug](https://github.com/filebase/Filebase/issues/41) returning unexpected results.
+
 ### 02/24/2019 - 1.0.23
 * Merged [Pull Request](https://github.com/filebase/Filebase/pull/49) Added support for order by multiple columns
 * Merged [Pull Request](https://github.com/filebase/Filebase/pull/46) Added ability to query document ids (internal id)

--- a/src/Database.php
+++ b/src/Database.php
@@ -430,7 +430,12 @@ class Database
     }
     public function getColumns()
     {
-        return array_keys($this->first());
+        $items=[];
+        foreach(array_keys($this->first()) as $item)
+        {
+            $items[]=strtolower($item);
+        }
+        return $items;
     }
 
 }

--- a/src/Database.php
+++ b/src/Database.php
@@ -15,7 +15,7 @@ class Database
     * Stores the version of Filebase
     * use $db->getVersion()
     */
-    const VERSION = '1.0.23';
+    const VERSION = '1.0.24';
 
     /**
     * $config

--- a/src/Database.php
+++ b/src/Database.php
@@ -422,11 +422,15 @@ class Database
             return $this->$method(...$args);
         }
 
-        if(method_exists(Query::class,$method)) {
-            return (new Query($this))->$method(...$args);
+        if(is_callable([$obj=(new Query($this)),$method])) {
+            return $obj->$method(...$args);
         }
 
         throw new \BadMethodCallException("method {$method} not found on 'Database::class' and 'Query::class'");
+    }
+    public function getColumns()
+    {
+        return array_keys($this->first());
     }
 
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -246,4 +246,44 @@ class Query extends QueryLogic
             }
         }
     }
+    public function __call($method,$args)
+    {
+        if(method_exists($this,$method))
+        {
+            return $method(...$args);
+        }
+
+        if($name=$this->methodMatchs($method))
+        {
+            $names=$this->database->getColumns();
+            if(in_array($name,$names))
+            {
+                if(count($args) == 1)
+                {
+                    return $this->where($name,'==',$args[0]);
+                }
+                if(count($args) == 2)
+                {
+                    return $this->where($name,$args[0],$args[1]);
+                }
+                throw new \InvalidArgumentException("input count must be 1 or 2 " . count($args) . "given");
+            }
+        }
+        throw new \BadMethodCallException('method not found on '.__CLASS__);
+        
+    }
+    /**
+     * methodMatchs
+     * find where* with regex
+     */
+    public function methodMatchs($method)
+    {
+        $patern='/^where(.*?)\s*$/is';
+        preg_match($patern,$method,$result);
+        if(isset($result[1]))
+        {
+            return strtolower($result[1]);
+        }
+        return false;
+    }
 }

--- a/src/Query.php
+++ b/src/Query.php
@@ -246,11 +246,14 @@ class Query extends QueryLogic
             }
         }
     }
+    /**
+     * call magic method
+     */
     public function __call($method,$args)
     {
         if(method_exists($this,$method))
         {
-            return $method(...$args);
+            return $this->$method(...$args);
         }
 
         if($name=$this->methodMatchs($method))

--- a/src/QueryLogic.php
+++ b/src/QueryLogic.php
@@ -42,6 +42,29 @@ class QueryLogic
         }
     }
 
+    private function loadDocuments()
+    {
+        $predicates = $this->predicate->get();
+
+        if ($this->cache===false)
+        {
+            $this->documents = $this->database->findAll(true,false);
+            return $this;
+        }
+
+        $this->cache->setKey(json_encode($predicates));
+
+        if ($cached_documents = $this->cache->get())
+        {
+            $this->documents = $cached_documents;
+
+            $this->sort();
+            $this->offsetLimit();
+             return $this;
+        }
+        $this->documents = $this->database->findAll(true,false);
+        return $this;
+    }
     /**
     * run
     *
@@ -57,22 +80,7 @@ class QueryLogic
             $predicates = 'findAll';
         }
 
-        if ($this->cache !== false)
-        {
-            $this->cache->setKey(json_encode($predicates));
-
-            if ($cached_documents = $this->cache->get())
-            {
-                $this->documents = $cached_documents;
-
-                $this->sort();
-                $this->offsetLimit();
-
-                return $this;
-            }
-        }
-
-        $this->documents = $this->database->findAll(true,false);
+        $this->loadDocuments();
 
         if ($predicates !== 'findAll')
         {

--- a/src/QueryLogic.php
+++ b/src/QueryLogic.php
@@ -45,7 +45,10 @@ class QueryLogic
     private function loadDocuments()
     {
         $predicates = $this->predicate->get();
-
+        if (empty($predicates))
+        {
+            $predicates = 'findAll';
+        }
         if ($this->cache===false)
         {
             $this->documents = $this->database->findAll(true,false);
@@ -81,7 +84,7 @@ class QueryLogic
         }
 
         $this->loadDocuments();
-
+        
         if ($predicates !== 'findAll')
         {
             $this->documents = $this->filter($this->documents, $predicates);

--- a/src/QueryLogic.php
+++ b/src/QueryLogic.php
@@ -42,6 +42,10 @@ class QueryLogic
         }
     }
 
+    /**
+    * loadDocuments
+    *
+    */
     private function loadDocuments()
     {
         $predicates = $this->predicate->get();
@@ -63,11 +67,12 @@ class QueryLogic
 
             $this->sort();
             $this->offsetLimit();
-             return $this;
+            return $this;
         }
         $this->documents = $this->database->findAll(true,false);
         return $this;
     }
+
     /**
     * run
     *

--- a/tests/DatabaseTest.php
+++ b/tests/DatabaseTest.php
@@ -338,4 +338,25 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase
         $this->assertInternalType('string', $result_from_cache[0]['email']);
         $db->flush(true);
     }
+    public function test_must_return_name_of_culomns()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/saved',
+            'cache' => true
+        ]);
+
+        $db->flush(true);
+
+        for ($x = 1; $x <= 10; $x++)
+    	{
+    		$user = $db->get(uniqid());
+    		$user->name  = 'John';
+            $user->email = 'john@example.com';
+    		$user->save();
+    	}
+
+        $r=$db->first();
+        $names=array_keys($r);
+        $this->assertEquals($names, $db->getColumns());
+    }
 }

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -1261,4 +1261,66 @@ class QueryTest extends \PHPUnit\Framework\TestCase
 
         $db->flush(true);
     }
+    public function test_must_detect_and_return_culomn_with_regex()
+    {
+        $query=new Query(new Database);
+        $result=$query->methodMatchs('whereName');
+        $this->assertEquals('name',$result);
+    }
+    public function test_must_call_method_on_regex_matched_culumn()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/users_1',
+            'cache' => false
+        ]);
+
+        $db->flush(true);
+
+        $user1 = $db->get('obj1')->save(['name' => 'Bob','email'=>'email@addres.com']);
+        $user2 = $db->get('obj2')->save(['name' => 'Jenny','email'=>'email@addres.com']);
+        $user3 = $db->get('obj3')->save(['name' => 'Cyrus','email'=>'email@addres.com']);
+
+        // check with one input
+        $test1 = $db->query()->whereName('Bob')->first();
+        $expected = ['name' => 'Bob','email'=>'email@addres.com'];
+        $this->assertEquals($expected, $test1);
+
+        // check with two input 
+        $test1 = $db->query()->whereEmail('==','email@addres.com')->first();
+        $expected = ['name' => 'Bob','email'=>'email@addres.com'];
+        $this->assertEquals($expected, $test1);
+
+        // check with two input withour query()
+        $test1 = $db->whereEmail('==','email@addres.com')->first();
+        $expected = ['name' => 'Bob','email'=>'email@addres.com'];
+        $this->assertEquals($expected, $test1);
+
+        $db->flush(true);
+    }
+    public function test_must_return_exeption_on_none_exist_method()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/users_1',
+            'cache' => false
+        ]);
+
+        $db->flush(true);
+
+        $user1 = $db->get('obj1')->save(['name' => 'Bob','email'=>'email@addres.com']);
+        $this->expectException(\BadMethodCallException::class);
+        $db->query()->wherenone('name')->first();
+    }
+    public function test_must_return_exeption_on_empty_whereName_call_method()
+    {
+        $db = new \Filebase\Database([
+            'dir' => __DIR__.'/databases/users_1',
+            'cache' => false
+        ]);
+
+        $db->flush(true);
+
+        $user1 = $db->get('obj1')->save(['name' => 'Bob','email'=>'email@addres.com']);
+        $this->expectException(\InvalidArgumentException::class);
+        $db->query()->whereName()->first();
+    }
 }


### PR DESCRIPTION
in  normal mode can search in db with 

`$db->where('name','==','sam')->first();`

with this commit changes can search  in other way easy and shorter : 

`$db->whereName('sam')->first(); // equals  ('name','==','sam')`

  also can set oparator

`$db->whereName('like','sam')->first(); // equals  ('name','like','sam')`

> where* can be use for all custom names like whereEmail, whereHGFJH , ...

.
.by my mistake maybe some commits are duplicate :/
.