### PR TITLE
Generate AutoId for new Records

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -77,6 +77,16 @@ class Config
     public $validate = [];
 
     /**
+    * $auto_id_mode
+    *
+    * how new ids are generated when no id is given
+    * Possible values: autoincrement/hash
+    *
+    * default autoincrement
+    */
+    public $auto_id_mode = 'autoincrement';
+
+    /**
     * __construct
     *
     * This sets all the config variables (replacing its defaults)


### PR DESCRIPTION
Added the option to leave the id value empty when generating a new item via $db->get(). As suggested in feature request https://github.com/filebase/Filebase/issues/3 there are two config options for auto_id_mode, these are autoincrement and hash.

The option 'hash' will generate a random id with 8 characters. The option 'autoincrement' will result the highest current id +1.